### PR TITLE
fix: change category_group_code any into CategoryCode

### DIFF
--- a/@types/services.Places.d.ts
+++ b/@types/services.Places.d.ts
@@ -85,7 +85,7 @@ declare namespace kakao.maps.services {
      * 중요 카테고리만 그룹핑한 카테고리 그룹 코드
      * 예) FD6
      */
-    category_group_code: CategoryGroupCode;
+    category_group_code?: `${CategoryCode}` | `${Exclude<CategoryCode, "">}`[];
 
     /**
      * 중요 카테고리만 그룹핑한 카테고리 그룹명

--- a/@types/services.Places.d.ts
+++ b/@types/services.Places.d.ts
@@ -133,7 +133,7 @@ declare namespace kakao.maps.services {
     /**
      * 키워드 필터링을 위한 카테고리 코드
      */
-    category_group_code?: CategoryGroupCode;
+    category_group_code?: `${CategoryCode}` | `${Exclude<CategoryCode, "">}`[];
 
     /**
      * 중심 좌표. 특정 지역을 기준으로 검색한다.

--- a/dummy.ts
+++ b/dummy.ts
@@ -1,0 +1,3 @@
+const ASD: kakao.maps.services.PlacesSearchOptions = {
+  category_group_code: ["SW8"],
+};

--- a/dummy.ts
+++ b/dummy.ts
@@ -1,3 +1,0 @@
-const ASD: kakao.maps.services.PlacesSearchOptions = {
-  category_group_code: ["SW8"],
-};


### PR DESCRIPTION
안녕하세요. 제작해주신 라이브러리덕분에 너무 편하게 카카오 API를 통해서 개발중입니다.

`키워드`를 통해 검색할때 부여할 수 있는 옵션으로 category_group_code 가 있는데,
카테고리의 값, 그 값들의 배열을 받을 수 있는것을 확인했습니다.

```tsx

  const ps = new kakao.maps.services.Places();
  // 음식점만 받아옴
  ps.keywordSearch(value,callback,{
    category_group_code = "FD6"
  }
  
  // 음식점 및 카페를 받아옴
  ps.keywordSearch(value,callback,{
    category_group_code = ["FD6", "CE7"]
  }
```

실제 값이 추론되도록 인터페이스를 제공하면 `keywordSearch`를 사용하는 개발자들이 보다 쉽게 개발할 수 있을 것이라고 생각합니다.
