### PR TITLE
[추가] 폴리라인 생성 옵션에 map을 추가

### DIFF
--- a/@types/Circel.d.ts
+++ b/@types/Circel.d.ts
@@ -76,6 +76,11 @@ declare namespace kakao.maps {
 
   export interface CircleOptions {
     /**
+     * 원이 올라갈 지도
+     */
+    map?: Map;
+
+    /**
      * 중심 좌표
      */
     center: LatLng;

--- a/@types/Marker.d.ts
+++ b/@types/Marker.d.ts
@@ -160,7 +160,7 @@ declare namespace kakao.maps {
     /**
      * 마커가 올라갈 지도 또는 로드뷰
      */
-    map?: Map | Roadview | Roadview;
+    map?: Map | Roadview;
 
     /**
      * 마커의 좌표 또는 로드뷰에서의 시점

--- a/@types/Polygon.d.ts
+++ b/@types/Polygon.d.ts
@@ -71,6 +71,11 @@ declare namespace kakao.maps {
 
   export interface PolygonOptions {
     /**
+     * 다각형이 올라갈 지도
+     */
+    map?: Map;
+
+    /**
      * #xxxxxx 형태의 채움 색 (기본값: ‘#F10000’)
      */
     fillColor?: string;

--- a/@types/Polyline.d.ts
+++ b/@types/Polyline.d.ts
@@ -66,6 +66,11 @@ declare namespace kakao.maps {
 
   export interface PolylineOptions {
     /**
+     * 폴리라인이 올라갈 지도 또는 로드뷰
+     */
+    map?: Map | Roadview | Roadview;
+
+    /**
      * 화살표 여부
      */
     endArrow?: boolean;

--- a/@types/Polyline.d.ts
+++ b/@types/Polyline.d.ts
@@ -68,7 +68,7 @@ declare namespace kakao.maps {
     /**
      * 폴리라인이 올라갈 지도 또는 로드뷰
      */
-    map?: Map | Roadview | Roadview;
+    map?: Map;
 
     /**
      * 화살표 여부

--- a/@types/Rectangle.d.ts
+++ b/@types/Rectangle.d.ts
@@ -60,6 +60,11 @@ declare namespace kakao.maps {
 
   export interface RectangleOptions {
     /**
+     * 사각형이 올라갈 지도
+     */
+    map?: Map;
+
+    /**
      * 사각형의 영역
      */
     bounds: LatLngBounds;


### PR DESCRIPTION
안녕하세요! 폴리라인 생성 옵션에 map이 없어 추가했습니다!
참고한 코드는 [다음](https://apis.map.kakao.com/web/sample/calculatePolylineDistance/)입니다.

> 카카오 웹뷰 선의 거리 계산하기에서 발췌
```typescript
// 클릭한 위치를 기준으로 선을 생성하고 지도위에 표시합니다
clickLine = new kakao.maps.Polyline({
    map: map, // 선을 표시할 지도입니다 
    path: [clickPosition], // 선을 구성하는 좌표 배열입니다 클릭한 위치를 넣어줍니다
    strokeWeight: 3, // 선의 두께입니다 
    strokeColor: '#db4040', // 선의 색깔입니다
    strokeOpacity: 1, // 선의 불투명도입니다 0에서 1 사이값이며 0에 가까울수록 투명합니다
    strokeStyle: 'solid' // 선의 스타일입니다
});
        
```